### PR TITLE
Modification to be able to open and download files both in Bari disks…

### DIFF
--- a/cygno/__init__.py
+++ b/cygno/__init__.py
@@ -79,9 +79,9 @@ class cfile:
         self.x_resolution = x_resolution
         self.y_resolution = y_resolution
 
-def open_mid(run, path='/tmp/',  cloud=True,  tag='LNGS', verbose=False):
+def open_mid(run, path='/tmp/',  cloud=True,  Bari=False, tag='LNGS', verbose=False):
     import midas.file_reader
-    fname = s3.mid_file(run, tag=tag, cloud=cloud, verbose=verbose)
+    fname = s3.mid_file(run, tag=tag, cloud=cloud, Bari=Bari, verbose=verbose)
     if verbose: print(fname)
     if not cloud:
         if os.path.exists(path+tag+fname):
@@ -93,10 +93,10 @@ def open_mid(run, path='/tmp/',  cloud=True,  tag='LNGS', verbose=False):
         f = midas.file_reader.MidasFile(filetmp)  
     return f
 
-def open_root(run, path='/tmp/',  cloud=True,  tag='LAB', verbose=False):
+def open_root(run, path='/tmp/',  cloud=True,  Bari=False,  tag='LAB', verbose=False):
     import ROOT
     import root_numpy as rtnp
-    fname = s3.root_file(run, tag=tag, cloud=cloud, verbose=verbose)
+    fname = s3.root_file(run, tag=tag, cloud=cloud, Bari=Bari, verbose=verbose)
     if not cloud:
         fname=path+fname
     class cfile:
@@ -506,7 +506,7 @@ def ped_(run, path='./ped/', tag = 'LAB', posix=False, min_image_to_read = 0, ma
         return m_image, s_image  
     
 def ped_mid(run, path_file='/s3/cygno-data/', path_ped='./ped/', tag = 'LNGS', 
-            cloud=False, verbose=False):
+            cloud=False, Bari=False, verbose=False):
     #
     # run numero del run
     # path path lettura/scrittura piedistalli
@@ -534,7 +534,7 @@ def ped_mid(run, path_file='/s3/cygno-data/', path_ped='./ped/', tag = 'LNGS',
         # i file non esistono crea il file delle medie e delle sigma per ogni pixel dell'immagine
         if verbose: print (">>> Pedestal Maker! <<<")
         try:
-            mfile = open_mid(run=run, path=path_file, cloud=cloud, tag=tag, verbose=verbose)
+            mfile = open_mid(run=run, path=path_file, cloud=cloud, Bari=Bari, tag=tag, verbose=verbose)
         except:
             raise myError("openRunError: "+str(run))
             

--- a/cygno/s3.py
+++ b/cygno/s3.py
@@ -3,7 +3,8 @@
 #
 
 BAKET_POSIX_PATH = '/jupyter-workspace/cloud-storage/'
-BAKET_REST_PATH = 'https://s3.cloud.infn.it/v1/AUTH_2ebf769785574195bde2ff418deac08a/'
+BUCKET_REST_PATH = 'https://s3.cloud.infn.it/v1/AUTH_2ebf769785574195bde2ff418deac08a/'
+BUCKET_REST_PATH_BARI = 'https://swift.recas.ba.infn.it/'
 
 def kb2valueformat(val):
     import numpy as np
@@ -39,20 +40,24 @@ def open_aws_session(session, number_of_try=3, wait=10, verbose=False):
 #         if run <= 4504:
 #             BASE_URL  = BAKET_POSIX_PATH+'cygno/Data/'
 #     else:
-#         BASE_URL  = BAKET_REST_PATH+'cygno-data/'
+#         BASE_URL  = BUCKET_REST_PATH+'cygno-data/'
 #         if run <= 4504:
-#             BASE_URL  =  BAKET_REST_PATH+'cygnus/Data/'
+#             BASE_URL  =  BUCKET_REST_PATH+'cygnus/Data/'
     
 #     file_root = (tag+'/histograms_Run%05d.root' % run)
 #     if verbose: print(BASE_URL+file_root)
 #     return BASE_URL+file_root
 
 
-def root_file(run, tag='LAB', cloud=False, verbose=False):
+def root_file(run, tag='LAB', cloud=False, Bari=False, verbose=False):
     if cloud:
-        BASE_URL  = BAKET_REST_PATH+'cygno-data/'
+        if Bari:
+            BASE_URL = BUCKET_REST_PATH_BARI+'cygno-data/'
+        else:
+            BASE_URL  = BUCKET_REST_PATH+'cygno-data/'
+            
         if run <= 4504:
-            BASE_URL  =  BAKET_REST_PATH+'cygnus/Data/'
+            BASE_URL  =  BUCKET_REST_PATH+'cygnus/Data/'
         f  = BASE_URL+(tag+'/histograms_Run%05d.root' % run)
     else:
         f = (tag+'/histograms_Run%05d.root' % run)
@@ -60,9 +65,12 @@ def root_file(run, tag='LAB', cloud=False, verbose=False):
     if verbose: print(f)
     return f
 
-def mid_file(run, tag='LNGS', cloud=False, verbose=False):
+def mid_file(run, tag='LNGS', cloud=False, Bari=False, verbose=False):
     if cloud:
-        BASE_URL  = BAKET_REST_PATH+'cygno-data/'
+        if Bari:
+            BASE_URL = BUCKET_REST_PATH_BARI+'cygno-data/'
+        else:
+            BASE_URL  = BUCKET_REST_PATH+'cygno-data/'
         f = BASE_URL+(tag+'/run%05d.mid.gz' % run)
     else:
         f = ('/run%05d.mid.gz' % run)


### PR DESCRIPTION
Modification to be able to open and download files both in Bari disks and old cloud.

Added Bari boolean argument to open_mid and s3.mid_file. In s3.py the static url path to Bari location was added.

Default of Bari variable is false, so old versions of the reco or files will still be unaffected and search in old cloud path.